### PR TITLE
Flex based reflow of website for mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -387,6 +387,11 @@ img.tower {
   margin-right: auto;
 }
 
+.stats-content .row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 @media all and (max-width: 750px){
   .stats-content {
     margin-top: 0px;
@@ -703,7 +708,8 @@ p.tracks-des {
 \* ------------------------------------------------------------ */
 .sponsors-container {
   text-align: center;
-  padding: 15vh 0 15vh 0;
+  padding-top: 15vh;
+  padding-bottom: 15vh;
   background-color: #091822;
 }
 
@@ -712,6 +718,9 @@ p.tracks-des {
   font-size: 1em;
   color: #fff;
   opacity: .85;
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 67vw;
 }
 
 /* ------------------------------------------------------------ *\
@@ -864,8 +873,17 @@ progress::-webkit-progress-bar {
     font-size: 1.5em;
   }
 
-  .accordion a {
-    width: 330px;
+  section {
+    padding: 25px 20px 30px 25px;
+  }
+
+  .schedule-container {
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+
+  .faq-content {
+    width: initial;
   }
 }
 
@@ -891,10 +909,6 @@ progress::-webkit-progress-bar {
 
   span {
     font-size: .7em;
-  }
-
-  .sponsors-text {
-    padding: 16px;
   }
 
   .social-good-left {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -133,6 +133,7 @@
 \* ------------------------------------------------------------ */
 html {
   scroll-behavior: smooth;
+  font-size: 18px;
 }
 
 body {
@@ -146,7 +147,7 @@ img {
 }
 
 section {
-  padding: 50px;
+  padding: 30px 50px 30px 50px;
 }
 
 ul {
@@ -154,16 +155,16 @@ ul {
   padding-left: 0px;
 }
 
-#section-title {
+.section-title {
   font-family: Graphik,Helvetica Neue,Helvetica,Arial,sans-serif;
-  font-size: 2.6em;
+  font-size: 2.3em;
   font-weight: 700;
   color: #fff;
   text-transform: capitalize;
   margin: 0 auto;
   text-align: center;
   margin-bottom: 50px;
-  padding-top: 10px;
+  padding-top: 35px;
   letter-spacing: -.025em;
 }
 
@@ -242,7 +243,7 @@ button {
   color: rgba(13, 52, 68, .7);
   box-shadow: rgba(71, 53, 13, .2) 0px 3px 3px 0px !important;
   display: -webkit-inline-box;
-  font-size: 15px;
+  font-size: 0.83rem;
   font-weight: 500;
   letter-spacing: 0.4px;
   justify-content: center;
@@ -286,21 +287,8 @@ p {
   background-size: 400% 400%;
   -webkit-animation: Gradient 20s ease infinite;
 	-moz-animation: Gradient 20s ease infinite;
-	animation: Gradient 20s ease infinite;
-}
-
-@media all and (min-width: 750px){
-  .landing-container {
-    padding: 34vh 4vw 41vh 8vw;    
-    transform: translateY(0px);
-  }
-}
-
-@media all and (max-width: 750px){
-  .landing-container {
-    padding: 4vh 4vw 8vh 8vw;
-    transform: translateY(0px);
-  }
+  animation: Gradient 20s ease infinite;
+  padding: 34vh 4vw 41vh 8vw;
 }
 
 #hackdavis {
@@ -452,8 +440,20 @@ h2.stats {
   margin-top: 35px;  
 }
 
+.about-content .row, .tracks-container .row {
+  justify-content: space-evenly;
+}
+
+.readable-text-col {
+  max-width: 26em;
+}
+
+.social-good-right {
+  max-width: 20em;
+}
+
 h1.social-good-text {
-  font-size: 2.4em;
+  font-size: 2.13em;
   font-weight: 700;
   letter-spacing: -.025em;
   line-height: 1.1;
@@ -464,28 +464,17 @@ h1.social-good-text {
 
 p.about-text {
   font-family: "Graphik",Helvetica Neue,Helvetica,Arial,sans-serif;
-  font-size: 18px;
   font-weight: 400;
   -webkit-font-smoothing: subpixel-antialiased;
   text-align: -webkit-left;
   text-align: left;
-  max-width: 26em;
-  margin-top: 28px;
+  margin-top: 1.5rem;
   line-height: 1.5;
 }
 
-@media all and (max-width: 750px){
-  p.about-text {
-    font-size: 0.9em;    
-  }
-  #img-needs-offset {
-    margin-left: 5em;
-  }
-}
-
 img.social-good {
-  width: 78%;
   height: auto;
+  width: 100%;
 }
 
 /* ------------------------------------------------------------ *\
@@ -497,7 +486,7 @@ img.social-good {
 }
 
 img.tracks-img {
-  width: 23%;
+  width: 3rem;
   height: auto;
   transform: translateX(-8px);
 }
@@ -505,10 +494,12 @@ img.tracks-img {
 .tracks-picture {
   display: flex;
   justify-content: left;
+  flex-grow: 0;
 }
 
 h2.tracks-title {
   line-height: 1.25;
+  font-size: 1.7rem;
   font-weight: 700;
   color: #fff;
   text-align: left;
@@ -518,20 +509,13 @@ p.tracks-des {
   display: block;
   margin-right: auto;
   margin-left: auto;
-  font-size: 18px;
-  line-height: 30px;
   text-align: -webkit-left;
   text-align: left;
 }
 
 @media all and (max-width: 750px){
-  img.tracks-img {
-    width: 30%;
-  }
-  p.tracks-des {
-    font-size: 14px;
-    line-height: 20px;
-    padding-bottom: 32px;
+  .tracks-container .row .readable-text-col:not(:last-child) p.tracks-des {
+    padding-bottom: 2rem;
   }
 }
 
@@ -541,12 +525,6 @@ p.tracks-des {
 .schedule-container {
   text-align: center;
   background-color: #091822; 
-}
-
-@media all and (max-width: 750px) {
-  .schedule-container {
-    transform: translateY(-100px); 
-  }
 }
 
 .day {
@@ -560,13 +538,13 @@ p.tracks-des {
 .day-title {
   font-family: "Graphik",Helvetica Neue,Helvetica,Arial,sans-serif;
   font-weight: 300;
-  font-size: 20px;
+  font-size: 1.2rem;
   letter-spacing: .5px;
   text-transform: uppercase;
 }
 
 .day-date {
-	font-size: 45px;
+	font-size: 2.5rem;
 	padding-bottom: 20px;
 	font-weight: 700;
 	line-height: 40px;
@@ -593,7 +571,7 @@ p.tracks-des {
 }
 
 .time {
-	font-size: 35px;
+	font-size: 1.94rem;
 	font-weight: 500;
 	width: 40px;
 	line-height: 40px;
@@ -622,7 +600,6 @@ p.tracks-des {
 
 .event-title {
 	font-weight: 500;
-	font-size: 1em;
   line-height: 30px;
   text-transform: uppercase;
   float: left;
@@ -884,7 +861,7 @@ progress::-webkit-progress-bar {
   }
 
   h2.tracks-title {
-    font-size: 1.7em;
+    font-size: 1.5em;
   }
 
   .accordion a {
@@ -899,7 +876,7 @@ progress::-webkit-progress-bar {
 } */
 
 @media screen and (max-width: 768px) {
-  #section-title {
+  .section-title {
     margin-bottom: 40px;
   }
 
@@ -919,9 +896,35 @@ progress::-webkit-progress-bar {
   .sponsors-text {
     padding: 16px;
   }
+
+  .social-good-left {
+    margin-bottom: 2.5rem;
+  }
+
+  .tracks-header {
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 0.5rem;
+  }
+
+  .tracks-header > .tracks-picture {
+    flex-grow: 0;
+  }
+
+  img.tracks-img {
+    transform: translate3d(-8px, 3px, 0);
+  }
+
+  .tracks-header > .tracks-title {
+    flex-grow: 1;
+    margin-bottom: 0;
+  }
 }
 
 @media (max-width: 992px) {
+  html {
+    font-size: 16px;
+  }
   .list-features li:first-child {
     border-left: 1px solid #7FFFD6;
   }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -280,7 +280,6 @@ p {
   -ms-flex-align: start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  padding: 34vh 4vw 39vh 8vw;
   background: #141E30;
   background: -webkit-linear-gradient(-45deg, #141E30, #3e6692, #141E30);
   background: linear-gradient(-45deg, #141E30, #3e6692, #141E30);
@@ -290,9 +289,23 @@ p {
 	animation: Gradient 20s ease infinite;
 }
 
+@media all and (min-width: 750px){
+  .landing-container {
+    padding: 34vh 4vw 41vh 8vw;    
+    transform: translateY(0px);
+  }
+}
+
+@media all and (max-width: 750px){
+  .landing-container {
+    padding: 4vh 4vw 8vh 8vw;
+    transform: translateY(0px);
+  }
+}
+
 #hackdavis {
   color: white;
-  font-size: 3em;
+  font-size: 3em;  
   font-family: "Futura";
   letter-spacing: 1.6px;
 }
@@ -386,6 +399,13 @@ img.tower {
   margin-right: auto;
 }
 
+@media all and (max-width: 750px){
+  .stats-content {
+    margin-top: 0px;
+    padding: 0px;
+  }
+}
+
 h2.stats {
   font-weight: 700;
   font-size: 2.5em;
@@ -425,11 +445,11 @@ h2.stats {
 /******* about *******/
 .about-container {
   text-align: center;
-  background: #091822;
+  background: #091822;  
 }
 
 .about-content {
-  margin-top: 35px;
+  margin-top: 35px;  
 }
 
 h1.social-good-text {
@@ -452,6 +472,15 @@ p.about-text {
   max-width: 26em;
   margin-top: 28px;
   line-height: 1.5;
+}
+
+@media all and (max-width: 750px){
+  p.about-text {
+    font-size: 0.9em;    
+  }
+  #img-needs-offset {
+    margin-left: 5em;
+  }
 }
 
 img.social-good {
@@ -495,12 +524,29 @@ p.tracks-des {
   text-align: left;
 }
 
+@media all and (max-width: 750px){
+  img.tracks-img {
+    width: 30%;
+  }
+  p.tracks-des {
+    font-size: 14px;
+    line-height: 20px;
+    padding-bottom: 32px;
+  }
+}
+
 /* ------------------------------------------------------------ *\
 	schedule
 \* ------------------------------------------------------------ */
 .schedule-container {
   text-align: center;
-  background-color: #091822;
+  background-color: #091822; 
+}
+
+@media all and (max-width: 750px) {
+  .schedule-container {
+    transform: translateY(-100px); 
+  }
 }
 
 .day {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -288,7 +288,12 @@ p {
   -webkit-animation: Gradient 20s ease infinite;
 	-moz-animation: Gradient 20s ease infinite;
   animation: Gradient 20s ease infinite;
-  padding: 34vh 4vw 41vh 8vw;
+  padding: 25px 4vw 25px 8vw;
+  min-height: 100vh;
+}
+
+img.logo {
+  display: none;
 }
 
 #hackdavis {
@@ -310,8 +315,8 @@ img.hackdavis {
 }
 
 button.get-notified {
-  transform: translate3d(0, 50px, 0) rotate(0.0001deg);
-  -webkit-transform: translate3d(0, 50px, 0) rotate(0.0001deg);
+  transform: rotate(0.0001deg);
+  -webkit-transform: rotate(0.0001deg);
   background: linear-gradient(45deg,#66e6d8 90%,#7fffd6);
   margin: 0 15px 0 0;
   animation: fadeIn .5s both;
@@ -320,13 +325,14 @@ button.get-notified {
   backface-visibility: hidden;
   -webkit-perspective: 1000;
   perspective: 1000;
+  margin-top: 50px;
 }
 
 button.get-notified:hover {
   opacity: .95;
   box-shadow: rgba(71, 53, 13, 0.3) 0px 4px 8px 0px;
-  transform: translate3d(0, 45px, 0) rotate(0.0001deg);
-  -webkit-transform: translate3d(0, 45px, 0) rotate(0.0001deg);
+  transform: translate3d(0, -5px, 0) rotate(0.0001deg);
+  -webkit-transform: translate3d(0, -5px, 0) rotate(0.0001deg);
 
 }
 
@@ -342,33 +348,43 @@ button.sponsor-us {
   border-width: 1px;
   border-style: solid;
   border-color: #7fffd6;
-  transform: translate3d(0, 50px, 0) rotate(0.0001deg);
-  -webkit-transform: translate3d(0, 50px, 0) rotate(0.0001deg);
+  transform: rotate(0.0001deg);
+  -webkit-transform: rotate(0.0001deg);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   -webkit-perspective: 1000;
   perspective: 1000;
   animation: fadeIn .5s both;
   animation-delay: .5s;
+  margin-top: 50px;
 }
 
 button.sponsor-us:hover {
   opacity: .95;
   box-shadow: rgba(71, 53, 13, 0.3) 0px 4px 8px 0px;
   transform: translateY(45px) rotate(0.0001deg);
-  -webkit-transform: translateY(45px) rotate(0.0001deg);
+  -webkit-transform: translateY(-5px) rotate(0.0001deg);
 }
 
 .landing-picture {
-  padding-right: 9vw;
+  display: flex;
+  align-items: flex-end;
+  height: 100%;
 }
 
 img.tower {
   width: 100%;
   height: auto;
-  -webkit-transform: scale(2.8);
-  -ms-transform: scale(2.8);
-  transform: scale(2.8);
+  -webkit-transform: scale(1.9);
+  -ms-transform: scale(1.9);
+  transform: scale(1.9);
+
+  -webkit-transform-origin : 70% 90%;
+  -moz-transform-origin : 70% 90%;
+  -o-transform-origin : 70% 90%;
+  -ms-transform-origin : 70% 90%;
+  transform-origin : 70% 90%;
+
   animation: fadeIn .5s both;
   animation-delay: .85s;
   position: relative;
@@ -857,9 +873,6 @@ progress::-webkit-progress-bar {
 	breakpoints
 \* ------------------------------------------------------------ */
 @media screen and (max-width: 414px) {
-  .landing-container {
-    padding: 40vh 0px 25vh 8vw;
-  }
 
   img.tower {
     display: none;
@@ -887,6 +900,20 @@ progress::-webkit-progress-bar {
   }
 }
 
+@media screen and (max-width: 492px) {
+
+   .landing-container {
+     padding-left: 0 !important;
+     padding-right: 0 !important;
+   }
+
+   .landing-left {
+      flex-direction: column;
+      display: flex;
+      align-items: center;
+   }
+}
+
 /* @media (min-width: 576px) {
   .landing-picture {
     padding-right: 9vw;
@@ -894,8 +921,19 @@ progress::-webkit-progress-bar {
 } */
 
 @media screen and (max-width: 768px) {
+
+  .landing-container {
+    padding-left: 3rem;
+  }
+
   .section-title {
     margin-bottom: 40px;
+  }
+
+  img.logo {
+    display: block;
+    width: 200px;
+    transform: translateX(-10px);
   }
 
   .schedule-content {
@@ -932,6 +970,10 @@ progress::-webkit-progress-bar {
   .tracks-header > .tracks-title {
     flex-grow: 1;
     margin-bottom: 0;
+  }
+
+  .accordion a {
+    font-size: 1rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     <section class="about-container">
       <div class="container about-content" data-entrance="fade" data-entrance-delay="300">
         <div class="row">
-          <div class="col-md-7">
+          <div class="col-md-7" style="padding-bottom: 75px;">
             <h1 class="social-good-text" data-entrance="fade">
               <span class="underline hack">Hack for Social Good</span>
             </h1>
@@ -134,9 +134,9 @@
               On February 9-10, over 700 students, hackers, and creators will come together for 24 hours of hacking. 
               For the 4th year in a row, we are bringing the most talented students in California to address the world’s most pressing issues. 
             </p>
-          </div>
+          </div>          
           <div class="col-md-5">
-            <div class="tracks-picture center">
+            <div class="tracks-picture center" id="img-needs-offset">
               <img src="assets/img/v3-social-good-small.png" alt="social-good" class="social-good">
             </div>
           </div>
@@ -148,8 +148,8 @@
       <div class="container">
         <div class="row">
           <div class="col-md-4" data-entrance="fade" data-entrance-delay="100">
-            <div class="tracks-picture center">
-              <img src="assets/img/heart.svg" alt="heart" class="tracks-img">
+            <div class="tracks-picture center" id="tracks-picture-icon">
+              <img src="assets/img/heart.svg" alt="heart" class="tracks-img" id="tracks-picture-icon">
             </div>
             <h2 class="tracks-title">
               <span class="underline health">Health</span>
@@ -160,7 +160,7 @@
           </div>
           <div class="col-md-4" data-entrance="fade" data-entrance-delay="200">
             <div class="tracks-picture center">
-              <img src="assets/img/plant.svg" alt="plant" class="tracks-img">
+              <img src="assets/img/plant.svg" alt="plant" class="tracks-img" id="tracks-picture-icon">
             </div>
             <h2 class="tracks-title">
               <span class="underline environment">Environment</span>
@@ -171,7 +171,7 @@
           </div>
           <div class="col-md-4" data-entrance="fade" data-entrance-delay="300">
             <div class="tracks-picture center">
-              <img src="assets/img/book.svg" alt="book" class="tracks-img">
+              <img src="assets/img/book.svg" alt="book" class="tracks-img" id="tracks-picture-icon">
             </div>
             <h2 class="tracks-title">
               <span class="underline education">Education</span>

--- a/index.html
+++ b/index.html
@@ -67,10 +67,11 @@
       <div class="progress-container"></div>
     </progress>
 
-    <section class="landing-container" id="landing">
+    <section class="landing-container justify-content-center" id="landing">
       <div class="container-fluid">
         <div class="row">
-          <div class="col-md-7">
+          <div class="col-md-7 landing-left">
+            <img class="logo" src="assets/img/logo.png" />
             <h1 id="hackdavis">HACK<b>DAVIS</b></h1>
             <div class="details">
               <code class="facts" id="typed" style="animation: fadeIn .5s both;animation-delay: .30s;"></code>

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     <section class="about-container">
       <div class="container about-content" data-entrance="fade" data-entrance-delay="300">
         <div class="row">
-          <div class="col-md-7" style="padding-bottom: 75px;">
+          <div class="col-md-7 readable-text-col social-good-left">
             <h1 class="social-good-text" data-entrance="fade">
               <span class="underline hack">Hack for Social Good</span>
             </h1>
@@ -135,10 +135,8 @@
               For the 4th year in a row, we are bringing the most talented students in California to address the world’s most pressing issues. 
             </p>
           </div>          
-          <div class="col-md-5">
-            <div class="tracks-picture center" id="img-needs-offset">
-              <img src="assets/img/v3-social-good-small.png" alt="social-good" class="social-good">
-            </div>
+          <div class="col-md-5 social-good-right">
+            <img src="assets/img/v3-social-good-small.png" alt="social-good" class="social-good">
           </div>
         </div>
       </div>
@@ -147,35 +145,41 @@
     <section class="tracks-container">
       <div class="container">
         <div class="row">
-          <div class="col-md-4" data-entrance="fade" data-entrance-delay="100">
-            <div class="tracks-picture center" id="tracks-picture-icon">
-              <img src="assets/img/heart.svg" alt="heart" class="tracks-img" id="tracks-picture-icon">
+          <div class="col-md-4 readable-text-col" data-entrance="fade" data-entrance-delay="100">
+            <div class="tracks-header">
+              <div class="tracks-picture">
+                <img src="assets/img/heart.svg" alt="heart" class="tracks-img">
+              </div>
+              <h2 class="tracks-title">
+                <span class="underline health">Health</span>
+              </h2>
             </div>
-            <h2 class="tracks-title">
-              <span class="underline health">Health</span>
-            </h2>
             <p class="tracks-des">
               Develop a product that encourages people to live a healthier lifestyle. Help predict and prevent illnesses before they affect the body.
             </p>
           </div>
-          <div class="col-md-4" data-entrance="fade" data-entrance-delay="200">
-            <div class="tracks-picture center">
-              <img src="assets/img/plant.svg" alt="plant" class="tracks-img" id="tracks-picture-icon">
+          <div class="col-md-4 readable-text-col" data-entrance="fade" data-entrance-delay="200">
+            <div class="tracks-header">
+              <div class="tracks-picture">
+                <img src="assets/img/plant.svg" alt="plant" class="tracks-img">
+              </div>
+              <h2 class="tracks-title">
+                <span class="underline environment">Environment</span>
+              </h2>
             </div>
-            <h2 class="tracks-title">
-              <span class="underline environment">Environment</span>
-            </h2>
             <p class="tracks-des">
                 Aggregate public data to analyze or improve government green energy policies. Design solutions to reduce energy consumption in habitable spaces.
             </p>
           </div>
-          <div class="col-md-4" data-entrance="fade" data-entrance-delay="300">
-            <div class="tracks-picture center">
-              <img src="assets/img/book.svg" alt="book" class="tracks-img" id="tracks-picture-icon">
+          <div class="col-md-4 readable-text-col" data-entrance="fade" data-entrance-delay="300">
+            <div class="tracks-header">
+              <div class="tracks-picture">
+                <img src="assets/img/book.svg" alt="book" class="tracks-img">
+              </div>
+              <h2 class="tracks-title">
+                <span class="underline education">Education</span>
+              </h2>
             </div>
-            <h2 class="tracks-title">
-              <span class="underline education">Education</span>
-            </h2>
             <p class="tracks-des">
                 Discover new ways to faciliatate learning within the classroom. Enable accessible education for individuals with learning disabilities.
             </p>
@@ -185,7 +189,7 @@
     </section>
 
     <section class="schedule-container">
-      <p id="section-title" data-entrance="fade">
+      <p class="section-title" data-entrance="fade">
         <span class="underline schedule">schedule</span>
       </p>
       <div class="container">
@@ -338,8 +342,8 @@
       </div>
     </section>
 
-    <section class="faq-container">
-      <p id="section-title" data-entrance="fade">
+    <section class="faq-container container">
+      <p class="section-title" data-entrance="fade">
         <span class="underline faq">FAQ</span>
       </p>
       <div class="faq-content center">

--- a/index.html
+++ b/index.html
@@ -342,7 +342,8 @@
       </div>
     </section>
 
-    <section class="faq-container container">
+    <section class="faq-container">
+    <div class="container">
       <p class="section-title" data-entrance="fade">
         <span class="underline faq">FAQ</span>
       </p>
@@ -421,13 +422,16 @@
           </div>
         </div>
       </div>
+      </div>
     </section>
 
     <section class="sponsors-container">
-      <p id="section-title" data-entrance="fade">
-        <span class="underline sponsors">sponsors</span>
-      </p>
-      <p class="sponsors-text" data-entrance="fade">If you're interested in sponsoring us, please contact us at <a href="mailto:team@hackdavis.io">team@hackdavis.io</a></p>
+      <div class="container">
+        <p class="section-title" data-entrance="fade">
+          <span class="underline sponsors">sponsors</span>
+        </p>
+        <p class="sponsors-text" data-entrance="fade">If you're interested in sponsoring us, please contact us at <a href="mailto:team@hackdavis.io">team@hackdavis.io</a></p>
+      </div>
     </section>
 
     <section class="contact-container">


### PR DESCRIPTION
* Landing takes up entire screen height
* Use flex to center landing content
* Set root element font size to 18px on large screens, 16 on medium. Recalculate em's to maintain current sizing
* Center social good illustration on mobile and desktop
* tracks icons appear next to the header on mobile, are of fixed size
* sponsor text is now as big as FAQ text, not awkwardly bigger
* our logo takes up the top of the landing on mobile
* center landing content at 492px. Makes sense as it means the empty space on the right of the HackDavis title is less than 4/5 of title's width at this breakpoint, approximately.
* section padding from 100px horizontal to 50px horizontal on small screens
  *  Change the stats row margins from negative to zero, so that the green lines still appear

RIP my Tuesday