### PR TITLE
Move logo above the title

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -916,7 +916,7 @@ progress::-webkit-progress-bar {
 @media(min-width: 768px) {
   
   img.landing-logo {
-    width: 5rem;
+    width: 8rem;
   }
 
   #hackdavis {

--- a/index.html
+++ b/index.html
@@ -80,9 +80,9 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-md-7 landing-left">
+            <img class="logo landing-logo" src="assets/img/logo-small.png" />
             <div>
               <div class="title">
-                <img class="logo landing-logo" src="assets/img/logo-small.png" />
                 <h1 id="hackdavis">HACK<b>DAVIS</b></h1>
               </div>
               <div class="details">


### PR DESCRIPTION
Has been requested by HackDavis peeps. Kept the logo small so it doesn't compete as much with the main illustration.