### PR TITLE
Make stats section two columns for small screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -439,7 +439,8 @@ h2.stats {
 
 .list-features li {
   text-align: center;
-  padding: 40px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 .list-features li:first-child {
@@ -886,6 +887,10 @@ progress::-webkit-progress-bar {
 @media screen and (max-width: 414px) {
   .tower {
     display: none;
+  }
+
+  h2.stats {
+    font-size: 1.5em;
   }
 
   h1.social-good-text {

--- a/index.html
+++ b/index.html
@@ -113,19 +113,19 @@
     <section class="stats-container">
       <div class="container stats-content">
           <ul class="list-features justify-content-center row">
-            <li class="col-lg-3 col-sm-6" data-entrance="fade">
+            <li class="col-md-3 col-6" data-entrance="fade">
               <h2 class="stats">700<small>+</small></h2>
               <code>Hackers</code>
             </li>
-            <li class="col-lg-3 col-sm-6" data-entrance="fade" data-entrance-delay="100">
+            <li class="col-md-3 col-6" data-entrance="fade" data-entrance-delay="100">
               <h2 class="stats">24</h2>
               <code>Hours</code>
             </li>
-            <li class="col-lg-3 col-sm-6" data-entrance="fade" data-entrance-delay="200">
+            <li class="col-md-3 col-6" data-entrance="fade" data-entrance-delay="200">
               <h2 class="stats"><sup>$</sup>8000<small>+</small></h2>
               <code>Prizes</code>
             </li>
-            <li class="col-lg-3 col-sm-6" data-entrance="fade" data-entrance-delay="300">
+            <li class="col-md-3 col-6" data-entrance="fade" data-entrance-delay="300">
               <h2 class="stats">100<small>+</small></h2>
               <code>Projects</code>
             </li>


### PR DESCRIPTION
This is currently what the stats section looks like on mobile:

![image](https://user-images.githubusercontent.com/8833582/50076617-0cec1a00-0197-11e9-8e33-367e98a84f70.png)

This is a lot of scrolling for a small amount of content. This has been adjusted as follows so that there are now two columns instead of one for mobile.

![image](https://user-images.githubusercontent.com/8833582/50076719-4c1a6b00-0197-11e9-84f5-3399e16ba1ce.png)

The font size for the various number values had to be decreased on mobile to compensate for this change.

A bug was encountered in the edge case where the value was too big for the container. This causes overflow and ultimately results in the value not being centered.

![image](https://user-images.githubusercontent.com/8833582/50077280-d2837c80-0198-11e9-96fb-9727ecd8a38b.png)

This happens due to the left and right padding being set on the list elements. Removing such results in:

![image](https://user-images.githubusercontent.com/8833582/50077356-01015780-0199-11e9-8efb-31e5889c4e69.png)