### PR TITLE
Center everything on landing page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -993,6 +993,10 @@ progress::-webkit-progress-bar {
     padding-top: 15px;
   }
 
+  .details {
+    text-align: center;
+  }
+
   .sponsors-container {
     padding-top: 25px;
   }


### PR DESCRIPTION
At the moment, the logo, "HACKDAVIS", and the buttons are centered while the rest of the text isn't:

![image](https://user-images.githubusercontent.com/8833582/50079647-fcd83880-019e-11e9-89c3-eec59d157460.png)

This fixes it so that styling is consistent on the landing page.

![image](https://user-images.githubusercontent.com/8833582/50079664-08c3fa80-019f-11e9-9ed1-d87974e7d84f.png)
