### PR TITLE
Scale and align landing page properly in regards to tower image

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -391,7 +391,7 @@ button.sponsor-us:hover {
 
 .landing-picture {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   height: 100%;
 }
 
@@ -917,19 +917,6 @@ progress::-webkit-progress-bar {
   }
 }
 
-@media screen and (max-width: 492px) {
-   .landing-container {
-     padding-left: 0 !important;
-     padding-right: 0 !important;
-   }
-
-   .landing-left {
-      flex-direction: column;
-      display: flex;
-      align-items: center;
-   }
-}
-
 @media(min-width: 768px) {
   img.landing-logo {
     width: 8rem;
@@ -947,7 +934,14 @@ progress::-webkit-progress-bar {
   }
 
   .landing-container {
-    padding-left: 3rem;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .landing-left {
+     flex-direction: column;
+     display: flex;
+     align-items: center;
   }
 
   .section-title {

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     </progress>
 
     <section class="landing-container justify-content-center" id="landing">
-      <div class="container-fluid">
+      <div class="container">
         <div class="row">
           <div class="col-md-7 landing-left">
             <img class="logo landing-logo" src="assets/img/logo-small.png" />


### PR DESCRIPTION
From screen size widths of 492px to 768px, the landing page content is left aligned but the tower image is not present.

![image](https://user-images.githubusercontent.com/8833582/50081016-437b6200-01a2-11e9-8be6-e8d0f72866b4.png)

This has been fixed so that the content is only left aligned when the tower image is present.

![image](https://user-images.githubusercontent.com/8833582/50081034-4ece8d80-01a2-11e9-97c0-da4b46a9dc91.png)

At 768 px, the tower image appears at the bottom and scales up from there as the screen size becomes larger.

![image](https://user-images.githubusercontent.com/8833582/50081109-83dae000-01a2-11e9-8b98-317b3d402f38.png)

The tower image has been modified to appear at the center initially instead of the bottom to ensure vertical consistency.

![image](https://user-images.githubusercontent.com/8833582/50081130-8fc6a200-01a2-11e9-994c-26597c7fddf2.png)

When the landing page is zoomed out on, the tower image becomes much larger than the content on the left side and causes a visual imbalance.

![image](https://user-images.githubusercontent.com/8833582/50080929-0dd67900-01a2-11e9-8111-1d5f8f8f0ee1.png)

This has been fixed by switching from `container-fluid` to `container` on the landing page container. This ensures consistency even when zoomed out.

![image](https://user-images.githubusercontent.com/8833582/50080892-feefc680-01a1-11e9-9041-a2fcb9da5ad8.png)
